### PR TITLE
Dynamic env variables Initial fix

### DIFF
--- a/sprinkler/lib/Config/Config.h
+++ b/sprinkler/lib/Config/Config.h
@@ -2,25 +2,57 @@
 // Created by shanisma on 04/07/2021.
 //
 
+// Expands macro for comparision
+// see use below
+#define DO_EXPAND(VAL)  VAL ## 1
+#define EXPAND(VAL)     DO_EXPAND(VAL)
+
+
 #define NODE_TYPE "sprinkler"
 
 // WIFI PARAMETERS
-#define WIFI_SSID ""
-#define WIFI_PASSWORD ""
+
+// PlatformIO already defines WIFI_SSID and related from build_flags
+// Redefining again will cause warning and empty value will be used
+// so comment them
+
+// #define WIFI_SSID ""
+// #define WIFI_PASSWORD ""
+
+
+// For additional info
+// Throw compile time error if WIFI_SSID is not defined (if sys env is not set)
+#ifndef WIFI_SSID
+#error "WIFI_SSID is not defined"
+#endif
+
 
 // CORE API PARAMETERS
-#define API_GATEWAY_URL ""
-#define API_GATEWAY_BASIC_AUTH_USER ""
-#define API_GATEWAY_BASIC_AUTH_PASSWORD ""
+// #define API_GATEWAY_URL ""
+// #define API_GATEWAY_BASIC_AUTH_USER ""
+// #define API_GATEWAY_BASIC_AUTH_PASSWORD ""
 // REGISTER TAG TO CORE
-#define NODE_TAG ""
+// #define NODE_TAG ""
+
+
+
+// IMPORTANT: Rare case as it's neither int nor string
+// Uncomment below lines if you're sure you'll pass false or true ( without qoutes )
+// #ifndef CHECK_NODE_TAG_DUPLICATE
 #define CHECK_NODE_TAG_DUPLICATE false
+// #endif
 
 // MQTT SERVER PARAMETERS
-#define MQTT_SERVER ""
+// #define MQTT_SERVER ""
+
+// Use default 1883 port if MQTT_PORT is not defined
+#if !defined(MQTT_PORT) || (EXPAND(MQTT_PORT) == 1)
 #define MQTT_PORT 1883
-#define MQTT_USER ""
-#define MQTT_PASSWORD ""
+#endif
+
+// #define MQTT_USER ""
+// #define MQTT_PASSWORD ""
+
 // MQTT TOPICS
 #define SENSOR_TOPIC "sprinkler/sensor"
 #define SENSOR_CONTROLLER "sprinkler/controller"

--- a/sprinkler/platformio.ini
+++ b/sprinkler/platformio.ini
@@ -13,22 +13,22 @@ platform = espressif32
 board = esp32dev
 board_build.mcu = esp32
 framework = arduino
-lib_deps =
+lib_deps = 
 	Wire
 	adafruit/Adafruit BusIO@^1.7.5
 	bblanchon/ArduinoJson@^6.17.0
 	adafruit/Adafruit ST7735 and ST7789 Library@^1.6.0
 	adafruit/Adafruit GFX Library@^1.10.2
 	knolleary/PubSubClient@^2.8.0
-build_flags =
-	-D WIFI_SSID=${sysenv.WIFI_SSID}
-	-D WIFI_PASSWORD=${sysenv.WIFI_PASSWORD}
-	-D API_GATEWAY_URL=${sysenv.API_GATEWAY_URL}
-	-D API_GATEWAY_BASIC_AUTH_USER=${sysenv.API_GATEWAY_BASIC_AUTH_USER}
-	-D API_GATEWAY_BASIC_AUTH_PASSWORD=${sysenv.API_GATEWAY_BASIC_AUTH_PASSWORD}
-	-D NODE_TAG=${sysenv.NODE_TAG}
-	-D CHECK_NODE_TAG_DUPLICATE=${sysenv.CHECK_NODE_TAG_DUPLICATE}
-	-D MQTT_SERVER=${sysenv.MQTT_SERVER}
-	-D MQTT_PORT=${sysenv.MQTT_PORT}
-	-D MQTT_USER=${sysenv.MQTT_USER}
-	-D MQTT_PASSWORD=${sysenv.MQTT_PASSWORD}
+build_flags = 
+	-D "WIFI_SSID=\"${sysenv.WIFI_SSID}\""
+	-D "WIFI_PASSWORD=\"${sysenv.WIFI_PASSWORD}\""
+	-D "API_GATEWAY_URL=\"${sysenv.API_GATEWAY_URL}\""
+	-D "API_GATEWAY_BASIC_AUTH_USER=\"${sysenv.API_GATEWAY_BASIC_AUTH_USER}\""
+	-D "API_GATEWAY_BASIC_AUTH_PASSWORD=\"${sysenv.API_GATEWAY_BASIC_AUTH_PASSWORD}\""
+	-D "NODE_TAG=\"${sysenv.NODE_TAG}\""
+	-D CHECK_NODE_TAG_DUPLICATE=${sysenv.CHECK_NODE_TAG_DUPLICATE} ; can only be true or false without any qoutes
+	-D "MQTT_SERVER=\"${sysenv.MQTT_SERVER}\""
+	-D MQTT_PORT=${sysenv.MQTT_PORT} ; port is int ( without qoutes )
+	-D "MQTT_USER=\"${sysenv.MQTT_USER}\""
+	-D "MQTT_PASSWORD=\"${sysenv.MQTT_PASSWORD}\""


### PR DESCRIPTION
I was successfully abled to pass environment variables with these changes, a close look at MQTT_PORT and CHECK_NODE_TAG_DUPLICATE is needed. I've commented the changes but Let me know if more explanation is needed.